### PR TITLE
Update Readme and node.js.yml

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-![Node.js CI](https://github.com/lmachens/cra-with-api/workflows/Node.js%20CI/badge.svg)
-
 # cra-with-api
 
 Boilerplate for Create-React-App with an Express.js API


### PR DESCRIPTION
- Remove status badge
  - It is linked to this repositories CI and not to the repositories using this as a template
- Change node.js.yml
  - Repositories which uses this template could use main instead of master.

I'm not sure if this makes sense because if someone uses this repository as template he/she would inherit the branch names and propably change the Readme anyway.

I just stumbled upon it using this repository as a guidance for my own template ...